### PR TITLE
Add @mattwthompson as a maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,3 +81,4 @@ about:
 extra:
   recipe-maintainers:
     - simonboothroyd
+    - mattwthompson


### PR DESCRIPTION
Currently @simonboothroyd is the only maintainer of this feedstock. I'd like to add myself as a maintainer to shoulder some of the burden.