### PR TITLE
Rebuild v0.4.0rc1 with correct SHA hash

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/openforcefield/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: bad05e7460286548ea1f38c1da9b01ea8b030fe5f67a4699ce75302cead267dc
+  sha256: f6ab87133f9e990754a630ad80db1d921401f9cbe7e52559fb34c6e25407b082
 
 build:
-  number: 0
+  number: 1
   
 outputs:
   - name: {{ name|lower }}-base


### PR DESCRIPTION
Builds after #12 failed: https://github.com/conda-forge/openff-evaluator-feedstock/runs/7457104598

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
