### PR TITLE
Avoid installing alongside incompatible ForceBalance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 *.pyc
 
 build_artifacts
-
-.DS_Store

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,8 @@ outputs:
         - rdkit
         - python-dateutil
         - pydantic <2.0.0a0
-
+      run_constrained:
+        - forcebalance >=1.9.5
 
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c66217e648fae3268a645ddc96ba88b6e031557caacf75ad598b5ab193125952
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: {{ name|lower }}-base


### PR DESCRIPTION
ForceBalance 1.9.5 is out and fixes some compatibility issues with the most recent release.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
