### PR TITLE
Remove `openmmtools` constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ outputs:
         - dask-jobqueue >=0.8.0
         - uncertainties
         # https://github.com/openforcefield/openff-evaluator/compare/v0.4.3...c6fb94346d0b8110089f644033e93ade7023e4e5#diff-1fbd3f1fb4002bd59bde4c5b1501a1ac0a580dd70b9bcf05cfb35ef066e4b0f9
-        - openmmtools >=0.22,<0.24
+        - openmmtools
         - pyyaml
         - requests
         - rdkit

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: af07951aea711d8289de464b41c144c3b15da95c04336cb98d339b0e50d3cc21
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name|lower }}-base


### PR DESCRIPTION
Version 0.24.2 (the latest online, I think) is used without obvious issues in CI. The existing constraint probably dates back to Yank complexities which are no longer relevant.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
